### PR TITLE
Update workshop

### DIFF
--- a/enhancing-a-promise/README.md
+++ b/enhancing-a-promise/README.md
@@ -749,4 +749,5 @@ To recap the steps we took:
 
 ### 🎉 &nbsp; Congratulations!
 ✅&nbsp;&nbsp; You have enhanced a Kratix Promise to suit your organisation's needs. This concludes our introduction to Kratix. <br />
-👉🏾&nbsp;&nbsp; Let's [see where to go from here](/final-thoughts/README.md).
+
+## 👉🏾&nbsp;&nbsp; Let's [see where to go from here](/final-thoughts/README.md).

--- a/installing-a-promise/README.md
+++ b/installing-a-promise/README.md
@@ -189,15 +189,6 @@ To recap the steps you took:
 
 This is only the beginning of working with Promises. Next you will deploy three different Promises to provide a complete solution for an application team.
 
-## <a name="teardown"></a>Tearing it all down
-The next section in this tutorial requires a clean Kratix installation. Before heading to it, please clean up your environment by running:
-
-```bash
-kind delete clusters platform worker
-```
-<br />
-
-
 ### 🎉 &nbsp; Congratulations!
 ✅&nbsp;&nbsp; You have installed a Kratix Promise and used it to create on-demand instances of a service. <br />
 ## 👉🏾&nbsp;&nbsp; Now you will [deploy a web app that uses multiple Kratix Promises](/using-multiple-promises/README.md).

--- a/installing-a-promise/README.md
+++ b/installing-a-promise/README.md
@@ -10,7 +10,7 @@ This is Part 2 of [a series](../README.md) illustrating how Kratix works. <br />
 
 # <a name="promise"></a>What is a Kratix Promise?
 
-Conceptually, Promises are the building blocks of Kratix that allow you to develop your platform incrementally. Technically, a Promise is a YAML document that defines a contract between the Platform and its users. We will explore more about this contract and the internals of a Kratix Promise in part 4 where you will [write your own Promise](/writing-a-promise/README.md).
+Promises are the building blocks of Kratix, they define a contract between the Platform and its users. We will explore more about this contract and the internals of a Kratix Promise in part 4 where you will [write your own Promise](/writing-a-promise/README.md).
 
 ## Kratix Promises
 
@@ -20,13 +20,15 @@ Conceptually, Promises are the building blocks of Kratix that allow you to devel
 * are sharable and reusable between platforms, teams, business units, and other organisations.
 * add up to a frictionless experience when platform users want to create services that they need to deliver value.
 
-Now that you know more about Kratix Promises, follow the steps below to install a Promise.
+Now that you know more about Promises, follow the steps below to install a Promise.
 
 <br />
 <hr>
 
 ## <a name="prerequisites"></a>Prerequisites
-You need a fresh installation of Kratix for this section. The simplest way to do so is by running the quick-start script from within the Kratix directory.
+You need a fresh installation of Kratix for this section, if you've only just completed Step 1 [Install Kratix across two KinD clusters](/installing-kratix/) your good to go, otherwise follow the instruction below.
+
+The simplest way to do so is by running the quick-start script from within the Kratix directory.
 
 You can run this command from the root of `kratix`:
 
@@ -34,7 +36,6 @@ You can run this command from the root of `kratix`:
 ./scripts/quick-start.sh --recreate
 ```
 
-Alternatively, you can go back to [Install Kratix across two KinD clusters](/installing-kratix/).
 <br />
 <br />
 
@@ -55,6 +56,7 @@ Now that your system is set up, you can install your first Kratix Promise! You s
 <br />
 
 ### <a name="install-promise"></a>Install the Promise
+In this example we are going to make Jenkins available to applications teams by publishing a Jenskins promise. For now we will use a pre-created Promise, in part 4 we will explore [writing a Promise](/writing-a-promise/).
 
 Install Kratix's sample Jenkins Promise.
 ```bash
@@ -74,7 +76,7 @@ jenkins.example.promise.syntasso.io   2021-05-10T12:00:00Z
 ```
 <br />
 
-Verify that your `worker` cluster has the Jenkins Operator to be able to create Jenkins instances.
+Part of deploying the Promise involves Kratix deploying the Jenkins Operator to the worker clusters. Verify its been deployed
 ```bash
 kubectl --context kind-worker --namespace default get pods
 ```
@@ -198,4 +200,4 @@ kind delete clusters platform worker
 
 ### 🎉 &nbsp; Congratulations!
 ✅&nbsp;&nbsp; You have installed a Kratix Promise and used it to create on-demand instances of a service. <br />
-👉🏾&nbsp;&nbsp; Now you will [deploy a web app that uses multiple Kratix Promises](/using-multiple-promises/README.md).
+## 👉🏾&nbsp;&nbsp; Now you will [deploy a web app that uses multiple Kratix Promises](/using-multiple-promises/README.md).

--- a/installing-kratix/README.md
+++ b/installing-kratix/README.md
@@ -183,9 +183,9 @@ kratix-workload-resources         True    Fetched revision: f2d918e21d4c5cc65791
 ```
 <br />
 
-Once Flux is installed and running, the Kratix resources will be visible on the `worker` cluster. 
+Once Flux is running, the Kratix installation on the `platform` cluster will have the ability to manage resources on the `worker` cluster. 
 
-Verify that you can deploy resources to `worker`&mdash;check if your "canary" resource has been deployed. This may take a few minutes so `--watch` will append updates to the bottom of the output.
+Verify that Kratix can deploy resources to the `worker` cluster&mdash;the first resource created by default is the `kratix-worker-system` namespace, check that the namespace has been created. This may take a few minutes so `--watch` will append updates to the bottom of the output.
 ```bash
 kubectl --context kind-worker get namespaces --watch
 ```

--- a/installing-kratix/README.md
+++ b/installing-kratix/README.md
@@ -219,4 +219,4 @@ To recap the steps we took:
 
 ### 🎉 &nbsp; Congratulations!
 ✅&nbsp;&nbsp; Kratix is now installed. <br />
-👉🏾&nbsp;&nbsp; Next you will [install an sample Kratix Promise](/installing-a-promise/README.md).
+## 👉🏾&nbsp;&nbsp; Next you will [install an sample Kratix Promise](/installing-a-promise/README.md).

--- a/using-multiple-promises/README.md
+++ b/using-multiple-promises/README.md
@@ -258,4 +258,5 @@ kind delete clusters platform worker
 
 ### 🎉 &nbsp; Congratulations!
 ✅&nbsp;&nbsp; You have deployed a web app that uses multiple Kratix Promises. <br />
-👉🏾&nbsp;&nbsp; Now you will [write your own Jenkins Promise to learn more about how Kratix Promises work](/writing-a-promise/README.md).
+
+## 👉🏾&nbsp;&nbsp; Now you will [write your own Jenkins Promise to learn more about how Kratix Promises work](/writing-a-promise/README.md).

--- a/using-multiple-promises/README.md
+++ b/using-multiple-promises/README.md
@@ -136,7 +136,7 @@ kourier-system         Active   1h
 
 Verify that the Kratix Resource Request was issued on the platform cluster.
 ```console
-kubectl get jenkins.example.promise.syntasso.io
+kubectl --context kind-platform get jenkins.example.promise.syntasso.io
 ```
 <br />
 
@@ -150,7 +150,7 @@ example       1m
 Verify the instance is created on the worker cluster<br/>
 <sub>(This may take a few minutes so `--watch` will watch the command)</sub>
 ```console
-kubectl get pods --namespace default --context kind-worker --watch
+kubectl --context kind-worker get pods --namespace default --watch
 ```
 <br />
 

--- a/writing-a-promise/README.md
+++ b/writing-a-promise/README.md
@@ -674,4 +674,5 @@ kind delete clusters platform worker
 
 ### 🎉 &nbsp; Congratulations!
 ✅&nbsp;&nbsp; You have written a Kratix Promise. <br />
-👉🏾&nbsp;&nbsp; Let's [see how to tailor Kratix Promises based on organisational context](/enhancing-a-promise/README.md).
+
+## 👉🏾&nbsp;&nbsp; Let's [see how to tailor Kratix Promises based on organisational context](/enhancing-a-promise/README.md).


### PR DESCRIPTION
parking lot of changes I thought about that could be discussed:

- Remove mentioning of flux?
  - for the first few stages of the workshop is it useful to even mention it?
- Reduce kubectl flags to shorter? `--namespace` > `-n` etc. Perhaps explain it at some point? Or is a certain level of kubectl experience already expected? A lot of the commands are very verbose atm
- Can we hardcore a default user/pass for jenkins? Fetching the credentials adds a lose of noise