### PR TITLE
Pin k8s version to 1.24

### DIFF
--- a/installing-kratix/README.md
+++ b/installing-kratix/README.md
@@ -116,7 +116,7 @@ Now that you know what the installation looks like, bring Kratix to life.
 
 Create your `platform` cluster and install Kratix and MinIO.
 ```bash
-kind create cluster --name platform
+kind create cluster --name platform --image kindest/node:v1.24.0
 kubectl apply --filename distribution/kratix.yaml
 kubectl apply --filename hack/platform/minio-install.yaml
 ```
@@ -163,7 +163,7 @@ sed -i'' -e "s/172.18.0.2/$PLATFORM_CLUSTER_IP/g" hack/worker/gitops-tk-resource
 
 Create your Kratix `worker` cluster and install [Flux](https://fluxcd.io/). This will create a cluster for running the X as-a-Service workloads:
 ```bash
-kind create cluster --name worker #Also switches kubectl context to worker
+kind create cluster --name worker --image kindest/node:v1.24.0 #Also switches kubectl context to worker
 kubectl apply --filename config/samples/platform_v1alpha1_worker_cluster.yaml --context kind-platform #register the worker cluster with the platform cluster
 kubectl apply --filename hack/worker/gitops-tk-install.yaml
 kubectl apply --filename hack/worker/gitops-tk-resources.yaml


### PR DESCRIPTION
Our current workshop falls over on kubernetes `1.25` as the postgres operator isn't supported for `1.25` 

https://github.com/zalando/postgres-operator/issues/1999
```
Looks like PodDisruptionBudget policy/v1beta1 got removed (policy/v1 is the new apiVersion), which is causing the Postgres Operator to fail to creat the instances
$ k logs postgres-operator-6649b754cd-5w42h msg="could not create cluster: could not create pod disruption budget: the server could not find the requested resource" cluster-name=default/acid-minimal-cluster pkg=controller worker=0
```

this PR pins all of our `kind create cluster` to `1.24`


```
rg "kind create"
installing-kratix/README.md
119:kind create cluster --name platform --image kindest/node:v1.24.0
166:kind create cluster --name worker --image kindest/node:v1.24.0 #Also switches kubectl context to worker

```